### PR TITLE
Translation to english, add viewport meta tag, fix some styles

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -56,7 +56,7 @@ $(document).ready(function() {
         if (items[y].rotated) {
           var rotatedP = document.createElement('p');
           rotatedP.appendChild(
-            document.createTextNode('Rotado')
+            document.createTextNode('Rotated')
           );
 
           var classAttr = document.createAttribute('class');
@@ -80,7 +80,7 @@ $(document).ready(function() {
 
       var maxHeightH2 = document.createElement('h2');
       document.getElementById('max-heights').appendChild(maxHeightH2);
-      maxHeightH2.innerHTML += 'Alto max ' + (x + 1) + '° placa: ' + largerEnd;
+      maxHeightH2.innerHTML += 'Max height bin number ' + (x + 1) + ': ' + largerEnd;
     }
   }
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -20,7 +20,7 @@ body {
 
 h1, h2, h3 {
   font-weight: 400;
-} 
+}
 
 p {
   font-weight: 300;
@@ -41,6 +41,9 @@ button {
 }
 
 #details {
+  display: flex;
+  flex-wrap: wrap;
+
   > div {
     width: 110px;
     border: 1px solid black;

--- a/app/models/bin_pack.rb
+++ b/app/models/bin_pack.rb
@@ -11,13 +11,13 @@ class BinPack
 
       items << item.new(
         "#{rect[:width]}x#{rect[:height]}",
-        rect[:width] + 3,
-        rect[:height] + 3
+        rect[:height],
+        rect[:width]
       )
     end
 
     bins = BinPacking::Bin.pack(items, [], BinPacking::Bin.new(
-      bin[:width], bin[:height], 0
+      bin[:height], bin[:width], 0
     ))
 
     bins.map do |bin|

--- a/app/views/bin_packing/index.html.erb
+++ b/app/views/bin_packing/index.html.erb
@@ -1,28 +1,27 @@
 <%= hidden_field_tag 'bins', @bins.to_json %>
 
-<h1>Nesting mágico en Ruby</h1>
+<h1>Bin packing problem</h1>
 
 <p>
-  Ingresa una pieza por línea, largo y ancho de la pieza
-  separada por coma.
+  Insert only one piece per line, height and width separated by a comma. (height, width)
 </p>
 
 <%= form_tag("/pack", method: "get") do %>
-  <%= label_tag(:bin_width, "Ancho placa") %>
+  <%= label_tag(:bin_width, "Bin height") %>
   <%= number_field_tag(:bin_width, @bin_width, step: 0.01) %>
 
-  <%= label_tag(:bin_height, "Largo placa") %>
+  <%= label_tag(:bin_height, "Bin width") %>
   <%= number_field_tag(:bin_height, @bin_height, step: 0.01) %>
 
-  <%= check_box_tag('rotate', 'yes', @rotate) %> Rotar
+  <%= check_box_tag('rotate', 'yes', @rotate) %> Rotate
 
   <div>
     <textarea name="measures" type="text"><%= @measures %></textarea>
   </div>
 
-  <button>Calcular</button>
+  <button>Calculate</button>
 
-  <h1>Resultado</h1>
+  <h1>Result</h1>
   <div id="max-heights"></div>
 
   <div id="result">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>BinpackRails</title>
+    <meta name="viewport" content="width=device-width, user-scalable=no">
 
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
     <link href='https://fonts.googleapis.com/css?family=Roboto:400,300,500,100' rel='stylesheet' type='text/css'>


### PR DESCRIPTION
#### What does this PR do?
- It translates the example from Spanish to English.
- It Improves some styles
- It Adds viewport meta tag

#### Any background context you want to provide?
The code of this repo by itself is not pretty good, I had to do it of this way and I thought it could be also useful for someone else. So, sorry for what you are going to deal with.

#### Screenshots
Common use:
![image](https://cloud.githubusercontent.com/assets/16837996/23753555/b12f3a62-04b8-11e7-9d74-84268c177873.png)

With a lot of rectangles loaded:
![image](https://cloud.githubusercontent.com/assets/16837996/23753571/c541f846-04b8-11e7-8311-60c1a5cd3c9b.png)